### PR TITLE
Added dockerfile and Makefile for easy building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stretch
+
+RUN apt-get update && \
+    apt-get install -y build-essential git gcc-multilib && \
+    git clone https://github.com/xoreaxeaxeax/movfuscator.git && \
+    cd movfuscator && \
+    /bin/sh build.sh && \
+    /bin/sh install.sh && \
+    /bin/sh check.sh
+
+
+
+ENTRYPOINT ["/usr/local/bin/movcc"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+
+build:
+	docker build .


### PR DESCRIPTION
If accepted this will add a Dockerfile for reference.

I ran into the same problems found in:
https://github.com/xoreaxeaxeax/movfuscator/issues/26
https://github.com/xoreaxeaxeax/movfuscator/issues/29

`gcc-multilib` package will provide the 32bit libraries needed in cases where the host building the application are all 64bit.

Let me know if there is anything I can improve/add/document to make this Merge ready. 