### PR TITLE
Bug fix with post scripts

### DIFF
--- a/post/adc.py
+++ b/post/adc.py
@@ -39,6 +39,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             if l.startswith("movb"):
                 b = 8

--- a/post/add.py
+++ b/post/add.py
@@ -33,6 +33,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             if l.startswith("movb"):
                 b = 8

--- a/post/andor.py
+++ b/post/andor.py
@@ -33,6 +33,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             if l.startswith("movb"):
                 s = "b"

--- a/post/cmpxchgxchg.py
+++ b/post/cmpxchgxchg.py
@@ -34,6 +34,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):

--- a/post/mov32.py
+++ b/post/mov32.py
@@ -36,6 +36,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):

--- a/post/pushpop.py
+++ b/post/pushpop.py
@@ -34,6 +34,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):

--- a/post/rand.py
+++ b/post/rand.py
@@ -30,6 +30,9 @@ def o_adc(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         b = 8
@@ -86,6 +89,9 @@ def o_add(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         b = 8
@@ -132,6 +138,9 @@ def o_andor(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         s = "b"
@@ -156,6 +165,9 @@ def o_rrrrr(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         b = 8
@@ -195,6 +207,9 @@ def o_sbb(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         s = "b"
@@ -237,6 +252,9 @@ def o_sub(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         s = "b"
@@ -269,6 +287,9 @@ def o_xadd(f, l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if l.startswith("movb"):
         b = 8
@@ -320,6 +341,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):

--- a/post/rereg.py
+++ b/post/rereg.py
@@ -59,6 +59,9 @@ def genreg(l):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     if "TR0" in source:
         source = source.replace("TR0", "r%d" % r0)
@@ -124,6 +127,9 @@ def rereg(l, asm, i):
         tok = l.find(",")
     source = l[l.index(" "):tok].strip()
     dest = l[tok+1:].strip()
+    end = dest.find(" ")
+    if end != -1:
+        dest = dest[:end]
 
     source_regs = re.findall(r'r\d+_', source)
     for r in source_regs:

--- a/post/risc.py
+++ b/post/risc.py
@@ -80,6 +80,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):
@@ -120,6 +123,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             if l.startswith("movb"):
                 s = "b"
@@ -192,6 +199,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             # warning: ebp used in a previous pass to load immediates.  it's
             # okay since it was loading 32 bit values, and won't be translated

--- a/post/rrrrr.py
+++ b/post/rrrrr.py
@@ -32,6 +32,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):
@@ -72,6 +75,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             if l.startswith("movb"):
                 b = 8

--- a/post/sbb.py
+++ b/post/sbb.py
@@ -39,6 +39,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             if l.startswith("movb"):
                 s = "b"

--- a/post/shuffle.py
+++ b/post/shuffle.py
@@ -78,12 +78,18 @@ def can_swap(l1, l2):
         tok1 = l1.find(",")
     source1 = l1[l1.index(" "):tok1].strip()
     dest1 = l1[tok1+1:].strip()
+    end = dest1.find(" ")
+    if end != -1:
+        dest1 = dest1[:end]
 
     tok2 = l2.find(",", l2.find(")"))
     if tok2 == -1:
         tok2 = l2.find(",")
     source2 = l2[l2.index(" "):tok2].strip()
     dest2 = l2[tok2+1:].strip()
+    end = dest2.find(" ")
+    if end != -1:
+        dest2 = dest2[:end]
 
     # assumes compiler outputs () around all memory references
 

--- a/post/sub.py
+++ b/post/sub.py
@@ -33,6 +33,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             if l.startswith("movb"):
                 s = "b"

--- a/post/xadd.py
+++ b/post/xadd.py
@@ -32,6 +32,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             # NOTE: requires M/o/Vfuscator to only produce dword constants
             if source.startswith("$"):
@@ -68,6 +72,10 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
+
 
             if l.startswith("movb"):
                 b = 8

--- a/post/xor.py
+++ b/post/xor.py
@@ -33,6 +33,9 @@ with open(sys.argv[1], 'w') as f:
                 tok = l.find(",")
             source = l[l.index(" "):tok].strip()
             dest = l[tok+1:].strip()
+            end = dest.find(" ")
+            if end != -1:
+                dest = dest[:end]
 
             if l.startswith("movb"):
                 s = "b"


### PR DESCRIPTION
Compiling a simple Hello World program generates assembly code that contains:
```
	# (external call)
	movl (sp), %esp  # <REQ>
	movl $printf, (external)
```

When using post/xor.py (and other post scripts), the corresponding instructions generated are:

```
	# (external call)
	#xor> movl (sp), %esp  # <REQ>
	xorl %ebx, %ebx
	xorl (sp), %ebx
	xorl %esp  # <REQ>, %ebx
	xorl %ebx, %esp  # <REQ>
```

The third instruction is the problematic:
`xorl %esp  # <REQ>, %ebx`

The root cause is that the comment (`# <REQ>`) is also being identified as the "destination" register
My change makes it discard the comment