### PR TITLE
Recommend running `check.sh` on a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ instructions, objdump the result, and run the program.
 ./check.sh
 ```
 
+For extra safety, you should run this on a VM.
+
 ## Usage
 
 Compile programs as you would with any traditional C compiler:


### PR DESCRIPTION
The rationale is to avoid undefined behavior (if there's a compiler bug that causes UB), and to reduce attack-surface if the server that hosts the AES implementation gets compromised